### PR TITLE
Updated .attacked command to be more versatile

### DIFF
--- a/plugins/cc/cc.js
+++ b/plugins/cc/cc.js
@@ -62,7 +62,7 @@ exports.attacked = {
       return;
     }
     
-    var regex = /^(\d+)\sfor\s(\d+).*$/;
+    var regex = /^(\d{1,2}).+(\d{1,2}).*$/;
     var arr = regex.exec(suffix);
     if (!arr) {
       msg.channel.sendMessage("Invalid format for /attacked");

--- a/plugins/cc/cc.js
+++ b/plugins/cc/cc.js
@@ -62,7 +62,7 @@ exports.attacked = {
       return;
     }
     
-    var regex = /^(\d{1,2}).+(\d{1,2}).*$/;
+    var regex = /^(\d{1,2}).+(\d).*$/;
     var arr = regex.exec(suffix);
     if (!arr) {
       msg.channel.sendMessage("Invalid format for /attacked");


### PR DESCRIPTION
The first really small pull request. If you like, I plan on doing this to the rest of the commands.

The commands are very strict in the formatting right now, and any good bot should allow for some variation for usability. What this update does is allow the `attacked` command to take in very shorthand of `.attacked 30 2` or something super verbose, with possibly many _accidental_ spaces like `.attacked    30   for   2   stars` where everything but the digits is ignored.